### PR TITLE
Update envcov.sh

### DIFF
--- a/envcov.sh
+++ b/envcov.sh
@@ -10,6 +10,7 @@ ENV_DIR="${DIR}"
 if [[ $DIR == *Pods/XcodeCoverage* ]]
 then
    echo "Using Cocoapods!"
+   cd ${DIR}
    cd ..
    cd ..
    


### PR DESCRIPTION
Fix a bug that env.sh was not found when you call `getcov` form outside the XcodeCoverage folder
